### PR TITLE
Mark tomli-2.0.0-pyhd8ed1ab_0 as broken

### DIFF
--- a/broken/tomli-2.0.0-py36.txt
+++ b/broken/tomli-2.0.0-py36.txt
@@ -1,0 +1,1 @@
+noarch/tomli-2.0.0-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

tomli 2.0.0 dropped Python 3.6 support. This has been fixed in build 1 (see https://github.com/conda-forge/tomli-feedstock/pull/11).

Ping @thewchan 
